### PR TITLE
Added Options to Export-Certificate to Export to Pfx

### DIFF
--- a/PSBouncyCastle.psm1
+++ b/PSBouncyCastle.psm1
@@ -605,12 +605,23 @@ param(
 
     [Parameter(Mandatory = $false)]
     [ValidateSet('PEM', 'DER')]
-    [string] $OutputFormat = 'DER'
+    [string] $OutputFormat = 'DER',
+
+    [ValidateSet("Cert","Pfx")]
+    [string] $X509ContentType = "Cert",
+
+    [Parameter(Mandatory = $false)]
+    [ValidateNotNull()]
+    [securestring] $Password
 )
 
     $outputPath = QualifyPath $OutputFile
 
-    $bytes = $Certificate.Export('Cert')
+    if ($X509ContentType -eq 'PFX' -and $Password -ne $null) {
+        $bytes = $Certificate.Export($X509ContentType, $Password)
+    } else {
+        $bytes = $Certificate.Export($X509ContentType)
+    }
 
     switch ($OutputFormat)
     {


### PR DESCRIPTION
Wanted to have the ability to export to Pfx with the private key. Could do this in the existing Export-Certificate cmdlet with some additional optional parameters as shown in this commit, or this could be its own cmdlet.
