### PR TITLE
Fix undefined $random in ConvertFrom-BouncyCastleCertificate

### DIFF
--- a/PSBouncyCastle.psm1
+++ b/PSBouncyCastle.psm1
@@ -82,7 +82,11 @@ param(
     [Org.BouncyCastle.Crypto.AsymmetricCipherKeyPair] $subjectKeyPair,
 
     [Parameter(Mandatory = $true)]
-    [string] $friendlyName
+    [string] $friendlyName,
+
+    # Allows you to specify the random number generator to be used. If not specified, a new one is created.
+    [Parameter(Mandatory = $false)]
+    [Org.BouncyCastle.Security.SecureRandom] $random = (New-SecureRandom)
 )
 
     $store = New-Object Org.BouncyCastle.Pkcs.Pkcs12Store


### PR DESCRIPTION
Encountered an error in `$store.Save()` this while trying out a script at https://github.com/ryanspletzer/Scripts/blob/master/PowerShell/PSBouncyCastleCertChainGenerationScript.ps1